### PR TITLE
installation of non-source files and creation of quick build task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ install:
   - pip3.5 install zbar-py==1.0.4
   - pyb install_dependencies
 # command to build project
-script: pyb analyze publish
+script: pyb analyze full publish install

--- a/build.py
+++ b/build.py
@@ -16,6 +16,7 @@ default_task = "publish"
 @init
 def init(project):
     project.plugin_depends_on("flake8", "~=3.2")
+    project.depends_on_requirements("requirements.txt")
 
     # directory with pytest modules
     project.set_property("dir_source_pytest_python", "src/unittest/python")
@@ -45,6 +46,19 @@ def assert_flake8_is_executable(logger):
     assert_can_execute(command_and_arguments=["flake8", "--version"],
                        prerequisite="flake8",
                        caller="plugin python.flake8")
+
+@task("full", description="Includes all of the data files in the installation process.")
+@after("prepare")
+def full_setup(project, logger):
+    # include the training data in the correct package
+    logger.info("Including the data files in the installation...")
+    img_pre_trained_data_path = "lib/python3.5/site-packages/image_preprocessing/trained_data/"
+    img_pre_templates_path = "lib/python3.5/site-packages/image_preprocessing/templates/"
+    project.install_file(img_pre_trained_data_path, "image_preprocessing/trained_data/dlib_face_recognition_resnet_model_v1.dat")
+    project.install_file(img_pre_trained_data_path, "image_preprocessing/trained_data/shape_predictor_face_landmarks.dat")
+    project.install_file(img_pre_templates_path, "image_preprocessing/templates/pp2.jpg")
+    project.install_file(img_pre_templates_path, "image_preprocessing/templates/temp_flag.jpg")
+    project.install_file(img_pre_templates_path, "image_preprocessing/templates/wap.jpg")
 
 @task
 @depends("prepare")

--- a/makefile
+++ b/makefile
@@ -1,6 +1,9 @@
 all:
 	pyb analyze publish install
 
+full:
+	pyb analyze full publish install
+
 lint:
 	pyb analyze
 
@@ -18,9 +21,6 @@ build:
 
 run:
 	cd target/dist/Java-the-Hutts-1.0.dev0/scripts/ && python run.py
-
-setup:
-	python setup.py install
 
 buildrun:
 	pyb analyze publish install


### PR DESCRIPTION
All the current non-source files (the trained data and the templates) will now be installed into the `image_preprocessing` folder in its relevant `site-packages` folder.

There is a new task (makefile rule) that has been added. If you run `make full`, the full installation with the inclusion of the non-source files will run. Be warned though, that such a build takes a lot more time than the usual one.

The `build.py` file has also been modified to add most of the dependencies of the project to the `setup.py` file, so now we can install the project with all of its dependencies with the `python3 setup.py install` command. NOTE that this also includes the `opencv-python` library, which may overwrite the one in your current development setup if you have the source distribution of OpenCV installed in your virtual environment. Therefore, `imwrite()` ought not to work anymore.